### PR TITLE
Show coding time in /friends/list endpoint, fixes #8

### DIFF
--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -7,9 +7,8 @@ use diesel::result::DatabaseErrorKind;
 
 use crate::{
     database::{self, get_user_by_name, remove_friend},
-    models::{FriendWithTime, FriendTimeSteps},
     error::TimeError,
-    models::UserId,
+    models::{FriendWithTime, FriendTimeSteps, UserId},
     DbPool,
 };
 

--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -7,6 +7,7 @@ use diesel::result::DatabaseErrorKind;
 
 use crate::{
     database::{self, get_user_by_name, remove_friend},
+    models::{FriendWithTime, FriendTimeSteps},
     error::TimeError,
     models::UserId,
     DbPool,
@@ -44,8 +45,31 @@ pub async fn add_friend(
 
 #[get("/friends/list")]
 pub async fn get_friends(user: UserId, db: Data<DbPool>) -> Result<impl Responder, TimeError> {
-    match block(move || database::get_friends(&db.get()?, user.id)).await? {
-        Ok(friends) => Ok(web::Json(friends)),
+    let conn = db.get()?;
+    match block(move || database::get_friends(&conn, user.id)).await? {
+        Ok(friends) => {
+            let friends_with_time: Vec<FriendWithTime> = friends.iter().map(|friend| {
+                FriendWithTime {
+                    username: friend.username.clone(),
+                    coding_time: FriendTimeSteps {
+                        all_time: match &db.get() {
+                            Ok(c) => database::get_user_coding_time_since(c, friend.id, chrono::NaiveDateTime::from_timestamp(0, 0)).unwrap_or(0),
+                            _ => 0
+                        },
+                        past_month: match &db.get() {
+                            Ok(c) => database::get_user_coding_time_since(c, friend.id, chrono::Local::now().naive_local() - chrono::Duration::days(30)).unwrap_or(0),
+                            _ => 0
+                        },
+                        past_week: match &db.get() {
+                            Ok(c) => database::get_user_coding_time_since(c, friend.id, chrono::Local::now().naive_local() - chrono::Duration::days(7)).unwrap_or(0),
+                            _ => 0
+                        },
+                    }
+                }
+            }).collect();
+
+            Ok(web::Json(friends_with_time))
+        },
         Err(e) => {
             error!("{}", e);
             Err(e)

--- a/src/database.rs
+++ b/src/database.rs
@@ -259,7 +259,7 @@ pub fn add_friend(
 pub fn get_friends(
     conn: &PooledConnection<ConnectionManager<PgConnection>>,
     user: i32,
-) -> Result<Vec<String>, TimeError> {
+) -> Result<Vec<RegisteredUser>, TimeError> {
     use crate::schema::{
         friend_relations::dsl::{friend_relations, greater_id, lesser_id},
         registered_users::dsl::*,
@@ -287,7 +287,6 @@ pub fn get_friends(
                     .filter(id.eq(cur_friend))
                     .first::<RegisteredUser>(conn)
                     .ok()?
-                    .username,
             )
         })
         .collect();

--- a/src/database.rs
+++ b/src/database.rs
@@ -286,7 +286,7 @@ pub fn get_friends(
                 registered_users
                     .filter(id.eq(cur_friend))
                     .first::<RegisteredUser>(conn)
-                    .ok()?
+                    .ok()?,
             )
         })
         .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,9 +57,9 @@ async fn main() -> std::io::Result<()> {
     );
 
     let heartbeat_store = Data::new(api::activity::HeartBeatMemoryStore::new());
-    let ratelimiter = RateLimiterStorage::new(config.max_requests_per_min.unwrap_or(8)).start();
+    let ratelimiter = RateLimiterStorage::new(config.max_requests_per_min.unwrap_or(30)).start();
     let heartbeat_ratelimiter =
-        RateLimiterStorage::new(config.max_heartbeats_per_min.unwrap_or(30)).start();
+        RateLimiterStorage::new(config.max_heartbeats_per_min.unwrap_or(8)).start();
     HttpServer::new(move || {
         let cors = Cors::default()
             .allowed_origin(&config.allowed_origin)

--- a/src/models.rs
+++ b/src/models.rs
@@ -149,3 +149,16 @@ pub struct PrivateLeaderboard {
     pub creation_time: chrono::NaiveDateTime,
     pub members: Vec<PrivateLeaderboardMember>,
 }
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct FriendTimeSteps {
+    pub all_time: i32,
+    pub past_month: i32,
+    pub past_week: i32
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct FriendWithTime {
+    pub username: String,
+    pub coding_time: FriendTimeSteps
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -154,11 +154,11 @@ pub struct PrivateLeaderboard {
 pub struct FriendTimeSteps {
     pub all_time: i32,
     pub past_month: i32,
-    pub past_week: i32
+    pub past_week: i32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct FriendWithTime {
     pub username: String,
-    pub coding_time: FriendTimeSteps
+    pub coding_time: FriendTimeSteps,
 }


### PR DESCRIPTION
Fixes #8 

`/friends/list` now returns a response with this format:
```json
[
  {
    "username": "user2",
    "coding_time": {
      "all_time": 11,
      "past_month": 11,
      "past_week": 11
    }
  }
]
```