### PR TITLE
Restructure database for testausserveri-id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25df3c03f1040d0069fcd3907e24e36d59f9b6fa07ba49be0eb25a794f036ba7"
+checksum = "a27e27b63e4a34caee411ade944981136fdfa535522dc9944d6700196cbd899f"
 dependencies = [
  "base64ct",
  "blake2",
@@ -553,24 +553,27 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.4.8"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
+checksum = "e531d0abf8147036383c88ce3785d9cda6fe1b8b1183021ffa01cf49c5819d24"
 dependencies = [
  "bitflags",
  "byteorder",
  "chrono",
  "diesel_derives",
+ "itoa",
  "pq-sys",
  "r2d2",
+ "serde_json",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "1.4.1"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
+checksum = "212ba0cdc611523c37f26c7b3b4aedb4af7cbfe9239c4e7736a8a7c82284d77b"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -1117,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+checksum = "e029e94abc8fb0065241c308f1ac6bc8d20f450e8f7c5f0b25cd9b8d526ba294"
 dependencies = [
  "base64ct",
  "rand_core",
@@ -1169,6 +1172,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
 dependencies = [
  "vcpkg",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ lto = true
 [dependencies]
 actix-web = { version = "4.0.1", features = ["macros","openssl"] }
 actix = "0.13"
-awc = "3.0.0-beta.21"
+awc = "3.0.0"
 actix-cors = "0.6"
 http = "0.2"
 regex = "1.5"
 
-diesel = { version = "1.4.8", features = ["postgres", "chrono", "r2d2"] }
+diesel = { version = "2.0.0-rc.0", features = ["postgres", "chrono", "r2d2", "serde_json"] }
 r2d2 = "0.8"
 
 log = "0.4"
@@ -35,8 +35,8 @@ toml = "0.5"
 futures = "0.3"
 futures-util = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
-dashmap = "5.1"
-argon2 = "0.3.4"
+dashmap = "5.2"
+argon2 = "0.4"
 rand = "0.8"
 dotenv = "0.15"
 url = "2.2"

--- a/migrations/2022-04-25-000010_testausid/down.sql
+++ b/migrations/2022-04-25-000010_testausid/down.sql
@@ -1,0 +1,43 @@
+ALTER TABLE testaustime_users
+ADD COLUMN auth_token CHAR(32),
+ADD COLUMN friend_code CHAR(24),
+ADD COLUMN registration_time TIMESTAMP;
+
+CREATE TABLE registered_users(
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(32) NOT NULL,
+    password BYTEA NOT NULL,
+    salt BYTEA NOT NULL,
+    auth_token CHAR(32) NOT NULL,
+    friend_code CHAR(24) NOT NULL,
+    registration_time TIMESTAMP NOT NULL
+);
+
+INSERT INTO registered_users(id, username, auth_token, friend_code, registration_time, password, salt)
+SELECT
+    u.id, u.username, u.auth_token, u.friend_code, u.registration_time, t.password, t.salt
+FROM
+    testaustime_users as t
+JOIN
+    user_identities as u
+ON
+    t.identity = u.id;
+
+DROP TABLE testaustime_users cascade;
+
+ALTER TABLE coding_activities
+DROP CONSTRAINT coding_activities_user_id_fkey,
+ADD CONSTRAINT coding_activities_user_id_fkey FOREIGN KEY (user_id) REFERENCES registered_users(id) ON DELETE CASCADE;
+
+ALTER TABLE friend_relations
+DROP CONSTRAINT friend_relations_greater_id_fkey,
+ADD CONSTRAINT friend_relations_greater_id_fkey FOREIGN KEY (greater_id) REFERENCES registered_users(id) ON DELETE CASCADE,
+DROP CONSTRAINT friend_relations_lesser_id_fkey,
+ADD CONSTRAINT friend_relations_lesser_id_fkey FOREIGN KEY (lesser_id) REFERENCES registered_users(id) ON DELETE CASCADE;
+
+ALTER TABLE leaderboard_members
+DROP CONSTRAINT leaderboard_members_user_id_fkey,
+ADD CONSTRAINT leaderboard_members_user_id_fkey FOREIGN KEY (user_id) REFERENCES registered_users(id) ON DELETE CASCADE;
+
+DROP TABLE user_identities cascade;
+DROP TABLE testausid_users;

--- a/migrations/2022-04-25-000010_testausid/up.sql
+++ b/migrations/2022-04-25-000010_testausid/up.sql
@@ -1,0 +1,48 @@
+CREATE TABLE user_identities (LIKE registered_users INCLUDING ALL);
+
+INSERT INTO user_identities SELECT * FROM registered_users;
+
+ALTER TABLE user_identities
+DROP COLUMN password,
+DROP COLUMN salt;
+
+ALTER TABLE coding_activities
+DROP CONSTRAINT coding_activities_user_id_fkey,
+ADD CONSTRAINT coding_activities_user_id_fkey FOREIGN KEY (user_id) REFERENCES user_identities(id) ON DELETE CASCADE;
+
+ALTER TABLE friend_relations
+DROP CONSTRAINT friend_relations_greater_id_fkey,
+ADD CONSTRAINT friend_relations_greater_id_fkey FOREIGN KEY (greater_id) REFERENCES user_identities(id) ON DELETE CASCADE,
+DROP CONSTRAINT friend_relations_lesser_id_fkey,
+ADD CONSTRAINT friend_relations_lesser_id_fkey FOREIGN KEY (lesser_id) REFERENCES user_identities(id) ON DELETE CASCADE;
+
+ALTER TABLE leaderboard_members
+DROP CONSTRAINT leaderboard_members_user_id_fkey,
+ADD CONSTRAINT leaderboard_members_user_id_fkey FOREIGN KEY (user_id) REFERENCES user_identities(id) ON DELETE CASCADE;
+
+ALTER TABLE registered_users
+RENAME TO testaustime_users;
+
+ALTER TABLE testaustime_users
+DROP COLUMN auth_token,
+DROP COLUMN friend_code,
+DROP COLUMN registration_time,
+DROP COLUMN username,
+ADD COLUMN identity INT;
+
+UPDATE testaustime_users
+SET identity = id;
+
+ALTER TABLE testaustime_users
+ALTER COLUMN identity SET NOT NULL,
+ADD CONSTRAINT testaustime_users_identity_fkey FOREIGN KEY (identity) REFERENCES user_identities(id) ON DELETE CASCADE;
+
+CREATE TABLE testausid_users(
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL,
+    service_id INT NOT NULL,
+    identity INT NOT NULL,
+    CONSTRAINT testausid_users_identity_fkey
+        FOREIGN KEY (identity)
+        REFERENCES user_identities(id)
+);

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -13,7 +13,7 @@ use crate::{
         get_user_by_token, new_user, regenerate_token, verify_user_password,
     },
     error::TimeError,
-    models::{SelfUser, TestaustimeUser, UserId, UserIdentity},
+    models::{SelfUser, UserId, UserIdentity},
     requests::*,
     DbPool,
 };

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -9,11 +9,11 @@ use actix_web::{
 
 use crate::{
     database::{
-        change_password, change_username, get_user_by_id, get_user_by_token, new_user,
-        regenerate_token, verify_user_password,
+        change_password, change_username, get_testaustime_user_by_id, get_user_by_id,
+        get_user_by_token, new_user, regenerate_token, verify_user_password,
     },
     error::TimeError,
-    models::{RegisteredUser, SelfUser, UserId},
+    models::{SelfUser, TestaustimeUser, UserId, UserIdentity},
     requests::*,
     DbPool,
 };
@@ -30,7 +30,7 @@ impl FromRequest for UserId {
                 let db: Data<DbPool> = db.await?;
                 let user = block(move || {
                     let Some(token) = auth.to_str().unwrap().trim().strip_prefix("Bearer ").to_owned() else { return Err(TimeError::Unauthorized) };
-                    get_user_by_token(&db.get()?, token)
+                    get_user_by_token(&mut db.get()?, token)
                 }).await?;
                 if let Ok(user) = user {
                     Ok(UserId { id: user.id })
@@ -44,7 +44,7 @@ impl FromRequest for UserId {
     }
 }
 
-impl FromRequest for RegisteredUser {
+impl FromRequest for UserIdentity {
     type Error = TimeError;
     type Future = Pin<Box<dyn Future<Output = actix_web::Result<Self, Self::Error>>>>;
 
@@ -56,7 +56,7 @@ impl FromRequest for RegisteredUser {
                 let db: Data<DbPool> = db.await?;
                 let user = block(move || {
                     let Some(token) = auth.to_str().unwrap().strip_prefix("Bearer ") else { return Err(TimeError::Unauthorized) };
-                    get_user_by_token(&db.get()?, token)
+                    get_user_by_token(&mut db.get()?, token)
                 }).await?;
                 if let Ok(user) = user {
                     Ok(user)
@@ -80,7 +80,9 @@ pub async fn login(
             "Password cannot be longer than 128 characters".to_string(),
         ));
     }
-    match block(move || verify_user_password(&db.get()?, &data.username, &data.password)).await? {
+    match block(move || verify_user_password(&mut db.get()?, &data.username, &data.password))
+        .await?
+    {
         Ok(Some(user)) => Ok(Json(SelfUser::from(user))),
         Ok(None) => Err(TimeError::Unauthorized),
         Err(e) => Err(e),
@@ -89,7 +91,7 @@ pub async fn login(
 
 #[post("/auth/regenerate")]
 pub async fn regenerate(user: UserId, db: Data<DbPool>) -> Result<impl Responder, TimeError> {
-    match block(move || regenerate_token(&db.get()?, user.id)).await? {
+    match block(move || regenerate_token(&mut db.get()?, user.id)).await? {
         Ok(token) => {
             let token = json!({ "token": token });
             Ok(Json(token))
@@ -115,7 +117,7 @@ pub async fn register(
         return Err(TimeError::BadUsername);
     }
     Ok(Json(
-        block(move || new_user(&db.get()?, &data.username, &data.password)).await??,
+        block(move || new_user(&mut db.get()?, &data.username, &data.password)).await??,
     ))
 }
 
@@ -131,9 +133,10 @@ pub async fn changeusername(
         ));
     }
 
-    let conn = db.get()?;
-    match block(move || get_user_by_id(&conn, userid.id)).await? {
-        Ok(user) => match block(move || change_username(&db.get()?, user.id, &data.new)).await? {
+    let mut conn = db.get()?;
+    match block(move || get_user_by_id(&mut conn, userid.id)).await? {
+        Ok(user) => match block(move || change_username(&mut db.get()?, user.id, &data.new)).await?
+        {
             Ok(_) => Ok(HttpResponse::Ok().finish()),
             Err(e) => Err(e),
         },
@@ -155,30 +158,19 @@ pub async fn changepassword(
             "Password has to be between 8 and 128 characters long".to_string(),
         ));
     }
-    // FIXME: This whole thing is just horrible
     let old = data.old.to_owned();
-    let clone = db.clone();
-    let clone2 = db.clone();
-    match block(move || get_user_by_id(&clone.get()?, userid.id)).await? {
-        Ok(user) => {
-            match block(move || verify_user_password(&clone2.get()?, &user.username, &old)).await? {
-                Ok(k) => {
-                    if k.is_some() || user.password.iter().all(|n| *n == 0) {
-                        // Some noobs don't have password (me)
-                        match change_password(&db.get()?, userid.id, &data.new) {
-                            Ok(_) => Ok(HttpResponse::Ok().finish()),
-                            Err(e) => Err(e),
-                        }
-                    } else {
-                        Err(TimeError::Unauthorized)
-                    }
-                }
-                Err(e) => Err(e),
-            }
+    let mut conn = db.get()?;
+    let mut conn2 = db.get()?;
+    let mut conn3 = db.get()?;
+    let user = block(move || get_user_by_id(&mut db.get()?, userid.id)).await??;
+    let tuser = block(move || get_testaustime_user_by_id(&mut conn, userid.id)).await??;
+    let k = block(move || verify_user_password(&mut conn2, &user.username, &old)).await??;
+    if k.is_some() || tuser.password.iter().all(|n| *n == 0) {
+        match change_password(&mut conn3, userid.id, &data.new) {
+            Ok(_) => Ok(HttpResponse::Ok().finish()),
+            Err(e) => Err(e),
         }
-        Err(e) => {
-            error!("{}", e);
-            Err(e)
-        }
+    } else {
+        Err(TimeError::Unauthorized)
     }
 }

--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -107,7 +107,7 @@ pub async fn remove(
     db: Data<DbPool>,
     body: String,
 ) -> Result<impl Responder, TimeError> {
-    let mut clone = db.clone();
+    let clone = db.clone();
     let friend = block(move || get_user_by_name(&mut clone.get()?, &body)).await??;
     let deleted = block(move || remove_friend(&mut db.get()?, user.id, friend.id)).await??;
     if deleted {

--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -18,9 +18,9 @@ pub async fn add_friend(
     body: String,
     db: Data<DbPool>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
+    let mut conn = db.get()?;
     match block(move || {
-        database::add_friend(&conn, user.id, body.trim().trim_start_matches("ttfc_"))
+        database::add_friend(&mut conn, user.id, body.trim().trim_start_matches("ttfc_"))
     })
     .await?
     {
@@ -36,10 +36,11 @@ pub async fn add_friend(
             })
         }
         Ok(friend) => {
-            let conn = db.get()?;
+            let mut conn = db.get()?;
             let friend_with_time = FriendWithTime {
                 username: friend.username.clone(),
-                coding_time: match block(move || get_coding_time_steps(&conn, friend.id)).await {
+                coding_time: match block(move || get_coding_time_steps(&mut conn, friend.id)).await
+                {
                     Ok(coding_time_steps) => coding_time_steps,
                     _ => CodingTimeSteps {
                         all_time: 0,
@@ -56,16 +57,16 @@ pub async fn add_friend(
 
 #[get("/friends/list")]
 pub async fn get_friends(user: UserId, db: Data<DbPool>) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
-    match block(move || database::get_friends(&conn, user.id)).await? {
+    let mut conn = db.get()?;
+    match block(move || database::get_friends(&mut conn, user.id)).await? {
         Ok(friends) => {
             let friends_with_time = futures::future::join_all(friends.iter().map(|friend| async {
-                let conn2 = db.get().unwrap();
+                let mut conn2 = db.get().unwrap();
                 let friend_id = friend.id;
-
                 return FriendWithTime {
                     username: friend.username.clone(),
-                    coding_time: match block(move || get_coding_time_steps(&conn2, friend_id)).await
+                    coding_time: match block(move || get_coding_time_steps(&mut conn2, friend_id))
+                        .await
                     {
                         Ok(coding_time_steps) => coding_time_steps,
                         _ => CodingTimeSteps {
@@ -91,7 +92,7 @@ pub async fn regenerate_friend_code(
     user: UserId,
     db: Data<DbPool>,
 ) -> Result<impl Responder, TimeError> {
-    match block(move || database::regenerate_friend_code(&db.get()?, user.id)).await? {
+    match block(move || database::regenerate_friend_code(&mut db.get()?, user.id)).await? {
         Ok(code) => Ok(web::Json(json!({ "friend_code": code }))),
         Err(e) => {
             error!("{}", e);
@@ -106,9 +107,9 @@ pub async fn remove(
     db: Data<DbPool>,
     body: String,
 ) -> Result<impl Responder, TimeError> {
-    let clone = db.clone();
-    let friend = block(move || get_user_by_name(&clone.get()?, &body)).await??;
-    let deleted = block(move || remove_friend(&db.get()?, user.id, friend.id)).await??;
+    let mut clone = db.clone();
+    let friend = block(move || get_user_by_name(&mut clone.get()?, &body)).await??;
+    let deleted = block(move || remove_friend(&mut db.get()?, user.id, friend.id)).await??;
     if deleted {
         Ok(HttpResponse::Ok().finish())
     } else {

--- a/src/api/leaderboards.rs
+++ b/src/api/leaderboards.rs
@@ -32,7 +32,7 @@ pub async fn create_leaderboard(
     if !super::VALID_NAME_REGEX.is_match(&body.name) {
         return Err(TimeError::BadLeaderboardName);
     }
-    match block(move || database::new_leaderboard(&db.get()?, creator.id, &body.name)).await? {
+    match block(move || database::new_leaderboard(&mut db.get()?, creator.id, &body.name)).await? {
         Ok(code) => Ok(web::Json(json!({ "invite_code": code }))),
         Err(e) => {
             error!("{}", e);
@@ -53,14 +53,14 @@ pub async fn get_leaderboard(
     path: Path<(String,)>,
     db: Data<DbPool>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
+    let mut conn = db.get()?;
     let name = path.0.clone();
-    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&conn, &name)).await? {
-        let conn = db.get()?;
-        if block(move || database::is_leaderboard_member(&conn, user.id, lid)).await?? {
+    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&mut conn, &name)).await? {
+        let mut conn = db.get()?;
+        if block(move || database::is_leaderboard_member(&mut conn, user.id, lid)).await?? {
             Ok(web::Json({
-                let conn = db.get()?;
-                block(move || database::get_leaderboard(&conn, &path.0)).await??
+                let mut conn = db.get()?;
+                block(move || database::get_leaderboard(&mut conn, &path.0)).await??
             }))
         } else {
             error!("{}", TimeError::Unauthorized);
@@ -78,13 +78,13 @@ pub async fn delete_leaderboard(
     path: Path<(String,)>,
     db: Data<DbPool>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
+    let mut conn = db.get()?;
     let name = path.0.clone();
-    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&conn, &name)).await? {
-        let conn = db.get()?;
-        if block(move || database::is_leaderboard_admin(&conn, user.id, lid)).await?? {
-            let conn = db.get()?;
-            block(move || database::delete_leaderboard(&conn, &path.0)).await??;
+    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&mut conn, &name)).await? {
+        let mut conn = db.get()?;
+        if block(move || database::is_leaderboard_admin(&mut conn, user.id, lid)).await?? {
+            let mut conn = db.get()?;
+            block(move || database::delete_leaderboard(&mut conn, &path.0)).await??;
             Ok(HttpResponse::Ok().finish())
         } else {
             error!("{}", TimeError::Unauthorized);
@@ -104,7 +104,7 @@ pub async fn join_leaderboard(
 ) -> Result<impl Responder, TimeError> {
     match block(move || {
         database::add_user_to_leaderboard(
-            &db.get()?,
+            &mut db.get()?,
             user.id,
             body.invite.trim().trim_start_matches("ttlic_"),
         )
@@ -134,10 +134,12 @@ pub async fn leave_leaderboard(
     path: Path<(String,)>,
     db: Data<DbPool>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
-    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&conn, &path.0)).await? {
-        let left = block(move || database::remove_user_from_leaderboard(&db.get()?, lid, user.id))
-            .await??;
+    let mut conn = db.get()?;
+    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&mut conn, &path.0)).await?
+    {
+        let left =
+            block(move || database::remove_user_from_leaderboard(&mut db.get()?, lid, user.id))
+                .await??;
         if left {
             Ok(HttpResponse::Ok().finish())
         } else {
@@ -156,17 +158,18 @@ pub async fn promote_member(
     db: Data<DbPool>,
     promotion: Json<LeaderboardUser>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
-    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&conn, &path.0)).await? {
-        let conn = db.get()?;
-        if block(move || database::is_leaderboard_admin(&conn, user.id, lid)).await?? {
-            let conn = db.get()?;
+    let mut conn = db.get()?;
+    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&mut conn, &path.0)).await?
+    {
+        let mut conn = db.get()?;
+        if block(move || database::is_leaderboard_admin(&mut conn, user.id, lid)).await?? {
+            let mut conn = db.get()?;
             if let Ok(newadmin) =
-                block(move || database::get_user_by_name(&conn, &promotion.user)).await?
+                block(move || database::get_user_by_name(&mut conn, &promotion.user)).await?
             {
-                let conn = db.get()?;
+                let mut conn = db.get()?;
                 if block(move || {
-                    database::promote_user_to_leaderboard_admin(&conn, lid, newadmin.id)
+                    database::promote_user_to_leaderboard_admin(&mut conn, lid, newadmin.id)
                 })
                 .await??
                 {
@@ -196,17 +199,18 @@ pub async fn demote_member(
     db: Data<DbPool>,
     demotion: Json<LeaderboardUser>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
-    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&conn, &path.0)).await? {
-        let conn = db.get()?;
-        if block(move || database::is_leaderboard_admin(&conn, user.id, lid)).await?? {
-            let conn = db.get()?;
+    let mut conn = db.get()?;
+    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&mut conn, &path.0)).await?
+    {
+        let mut conn = db.get()?;
+        if block(move || database::is_leaderboard_admin(&mut conn, user.id, lid)).await?? {
+            let mut conn = db.get()?;
             if let Ok(oldadmin) =
-                block(move || database::get_user_by_name(&conn, &demotion.user)).await?
+                block(move || database::get_user_by_name(&mut conn, &demotion.user)).await?
             {
-                let conn = db.get()?;
+                let mut conn = db.get()?;
                 if block(move || {
-                    database::demote_user_to_leaderboard_member(&conn, lid, oldadmin.id)
+                    database::demote_user_to_leaderboard_member(&mut conn, lid, oldadmin.id)
                 })
                 .await??
                 {
@@ -236,16 +240,17 @@ pub async fn kick_member(
     db: Data<DbPool>,
     kick: Json<LeaderboardUser>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
-    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&conn, &path.0)).await? {
-        let conn = db.get()?;
-        if block(move || database::is_leaderboard_admin(&conn, user.id, lid)).await?? {
-            let conn = db.get()?;
+    let mut conn = db.get()?;
+    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&mut conn, &path.0)).await?
+    {
+        let mut conn = db.get()?;
+        if block(move || database::is_leaderboard_admin(&mut conn, user.id, lid)).await?? {
+            let mut conn = db.get()?;
             if let Ok(kmember) =
-                block(move || database::get_user_by_name(&conn, &kick.user)).await?
+                block(move || database::get_user_by_name(&mut conn, &kick.user)).await?
             {
-                let conn = db.get()?;
-                if block(move || database::remove_user_from_leaderboard(&conn, lid, kmember.id))
+                let mut conn = db.get()?;
+                if block(move || database::remove_user_from_leaderboard(&mut conn, lid, kmember.id))
                     .await??
                 {
                     Ok(HttpResponse::Ok().finish())
@@ -272,12 +277,14 @@ pub async fn regenerate_invite(
     path: Path<(String,)>,
     db: Data<DbPool>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
-    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&conn, &path.0)).await? {
-        let conn = db.get()?;
-        if block(move || database::is_leaderboard_admin(&conn, user.id, lid)).await?? {
-            let conn = db.get()?;
-            let code = block(move || database::regenerate_leaderboard_invite(&conn, lid)).await??;
+    let mut conn = db.get()?;
+    if let Ok(lid) = block(move || database::get_leaderboard_id_by_name(&mut conn, &path.0)).await?
+    {
+        let mut conn = db.get()?;
+        if block(move || database::is_leaderboard_admin(&mut conn, user.id, lid)).await?? {
+            let mut conn = db.get()?;
+            let code =
+                block(move || database::regenerate_leaderboard_invite(&mut conn, lid)).await??;
             Ok(web::Json(json!({ "invite_code": code })))
         } else {
             error!("{}", TimeError::Unauthorized);

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -42,7 +42,7 @@ pub async fn delete_user(
     pool: Data<DbPool>,
     user: web::Json<UserAuthentication>,
 ) -> Result<impl Responder, TimeError> {
-    let mut clone = pool.clone();
+    let clone = pool.clone();
     if let Some(user) = block(move || {
         database::verify_user_password(&mut pool.get()?, &user.username, &user.password)
     })

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -8,7 +8,7 @@ use serde_derive::Deserialize;
 use crate::{
     database::{self, are_friends, get_activity, get_user_by_name},
     error::TimeError,
-    models::{RegisteredUser, UserId},
+    models::{UserId, UserIdentity},
     requests::DataRequest,
     DbPool,
 };
@@ -20,7 +20,7 @@ pub struct UserAuthentication {
 }
 
 #[get("/users/@me")]
-pub async fn my_profile(user: RegisteredUser) -> Result<impl Responder, TimeError> {
+pub async fn my_profile(user: UserIdentity) -> Result<impl Responder, TimeError> {
     Ok(web::Json(user))
 }
 
@@ -33,7 +33,7 @@ pub struct ListLeaderboard {
 #[get("/users/@me/leaderboards")]
 pub async fn my_leaderboards(user: UserId, db: Data<DbPool>) -> Result<impl Responder, TimeError> {
     Ok(web::Json(
-        block(move || database::get_user_leaderboards(&db.get()?, user.id)).await??,
+        block(move || database::get_user_leaderboards(&mut db.get()?, user.id)).await??,
     ))
 }
 
@@ -42,12 +42,13 @@ pub async fn delete_user(
     pool: Data<DbPool>,
     user: web::Json<UserAuthentication>,
 ) -> Result<impl Responder, TimeError> {
-    let clone = pool.clone();
-    if let Some(user) =
-        block(move || database::verify_user_password(&pool.get()?, &user.username, &user.password))
-            .await??
+    let mut clone = pool.clone();
+    if let Some(user) = block(move || {
+        database::verify_user_password(&mut pool.get()?, &user.username, &user.password)
+    })
+    .await??
     {
-        block(move || database::delete_user(&clone.get()?, user.id)).await??;
+        block(move || database::delete_user(&mut clone.get()?, user.id)).await??;
     }
     Ok(HttpResponse::Ok().finish())
 }
@@ -59,27 +60,29 @@ pub async fn get_activities(
     user: UserId,
     db: Data<DbPool>,
 ) -> Result<impl Responder, TimeError> {
-    let conn = db.get()?;
+    let mut conn = db.get()?;
     if path.0 == "@me" {
-        let data = block(move || get_activity(&conn, data.into_inner(), user.id)).await??;
+        let data = block(move || get_activity(&mut conn, data.into_inner(), user.id)).await??;
         Ok(web::Json(data))
     } else {
-        let friend_id = get_user_by_name(&conn, &path.0)?.id;
+        let friend_id = get_user_by_name(&mut conn, &path.0)?.id;
         if friend_id == user.id {
-            let conn = db.get()?;
-            let data = block(move || get_activity(&conn, data.into_inner(), friend_id)).await??;
+            let mut conn = db.get()?;
+            let data =
+                block(move || get_activity(&mut conn, data.into_inner(), friend_id)).await??;
             Ok(web::Json(data))
         } else {
             match block(move || {
-                let conn = db.get()?;
-                are_friends(&conn, user.id, friend_id)
+                let mut conn = db.get()?;
+                are_friends(&mut conn, user.id, friend_id)
             })
             .await?
             {
                 Ok(b) => {
                     if b {
-                        let data = block(move || get_activity(&conn, data.into_inner(), friend_id))
-                            .await??;
+                        let data =
+                            block(move || get_activity(&mut conn, data.into_inner(), friend_id))
+                                .await??;
                         Ok(web::Json(data))
                     } else {
                         Err(TimeError::Unauthorized)

--- a/src/database.rs
+++ b/src/database.rs
@@ -120,7 +120,7 @@ pub fn new_user(
 
     diesel::insert_into(testaustime_users::table)
         .values(&testaustime_user)
-        .execute(conn);
+        .execute(conn)?;
 
     Ok(new_user)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![feature(let_else, once_cell)]
 
 mod api;
-mod database;
+pub mod database;
 mod error;
 pub mod models;
 mod requests;

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,20 +7,39 @@ pub struct UserId {
 }
 
 #[derive(Queryable, Clone, Debug, Serialize)]
-pub struct RegisteredUser {
+pub struct UserIdentity {
     pub id: i32,
+    pub username: String,
     #[serde(skip_serializing)]
     pub auth_token: String,
     pub friend_code: String,
-    pub username: String,
+    pub registration_time: chrono::NaiveDateTime,
+}
+
+#[derive(Queryable, Clone, Debug, Serialize)]
+pub struct TestaustimeUser {
+    pub id: i32,
     #[serde(skip_serializing)]
     pub password: Vec<u8>,
     #[serde(skip_serializing)]
     pub salt: Vec<u8>,
-    pub registration_time: chrono::NaiveDateTime,
+    pub identity: i32,
+}
+
+use crate::schema::testaustime_users;
+
+#[derive(Insertable, Serialize, Clone)]
+#[diesel(table_name = testaustime_users)]
+pub struct NewTestaustimeUser {
+    #[serde(skip_serializing)]
+    pub password: Vec<u8>,
+    #[serde(skip_serializing)]
+    pub salt: Vec<u8>,
+    pub identity: i32,
 }
 
 // This is here so that vilepis doesn't actually give friends eachothers auth tokens
+// Fuck off
 #[derive(Clone, Debug, Serialize)]
 pub struct SelfUser {
     pub id: i32,
@@ -30,8 +49,8 @@ pub struct SelfUser {
     pub registration_time: chrono::NaiveDateTime,
 }
 
-impl From<RegisteredUser> for SelfUser {
-    fn from(u: RegisteredUser) -> SelfUser {
+impl From<UserIdentity> for SelfUser {
+    fn from(u: UserIdentity) -> SelfUser {
         SelfUser {
             id: u.id,
             auth_token: u.auth_token,
@@ -42,18 +61,14 @@ impl From<RegisteredUser> for SelfUser {
     }
 }
 
-use crate::schema::registered_users;
+use crate::schema::user_identities;
 
 #[derive(Insertable, Serialize, Clone)]
-#[table_name = "registered_users"]
-pub struct NewRegisteredUser {
+#[diesel(table_name = user_identities)]
+pub struct NewUserIdentity {
     pub auth_token: String,
     pub username: String,
     pub friend_code: String,
-    #[serde(skip_serializing)]
-    pub password: Vec<u8>,
-    #[serde(skip_serializing)]
-    pub salt: Vec<u8>,
     pub registration_time: chrono::NaiveDateTime,
 }
 
@@ -67,7 +82,7 @@ pub struct FriendRelation {
 use crate::schema::friend_relations;
 
 #[derive(Insertable)]
-#[table_name = "friend_relations"]
+#[diesel(table_name = friend_relations)]
 pub struct NewFriendRelation {
     pub lesser_id: i32,
     pub greater_id: i32,
@@ -89,7 +104,7 @@ pub struct CodingActivity {
 use crate::schema::coding_activities;
 
 #[derive(Insertable)]
-#[table_name = "coding_activities"]
+#[diesel(table_name = coding_activities)]
 pub struct NewCodingActivity {
     pub user_id: i32,
     pub start_time: chrono::NaiveDateTime,
@@ -111,7 +126,7 @@ pub struct Leaderboard {
 use crate::schema::leaderboards;
 
 #[derive(Insertable)]
-#[table_name = "leaderboards"]
+#[diesel(table_name = leaderboards)]
 pub struct NewLeaderboard {
     pub name: String,
     pub invite_code: String,
@@ -129,7 +144,7 @@ pub struct LeaderboardMember {
 use crate::schema::leaderboard_members;
 
 #[derive(Insertable)]
-#[table_name = "leaderboard_members"]
+#[diesel(table_name = leaderboard_members)]
 pub struct NewLeaderboardMember {
     pub leaderboard_id: i32,
     pub user_id: i32,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -38,25 +38,45 @@ table! {
 }
 
 table! {
-    registered_users (id) {
+    testausid_users (id) {
         id -> Int4,
-        auth_token -> Bpchar,
-        friend_code -> Bpchar,
-        username -> Varchar,
+        user_id -> Int4,
+        service_id -> Int4,
+        identity -> Int4,
+    }
+}
+
+table! {
+    testaustime_users (id) {
+        id -> Int4,
         password -> Bytea,
         salt -> Bytea,
+        identity -> Int4,
+    }
+}
+
+table! {
+    user_identities (id) {
+        id -> Int4,
+        username -> Varchar,
+        auth_token -> Bpchar,
+        friend_code -> Bpchar,
         registration_time -> Timestamp,
     }
 }
 
-joinable!(coding_activities -> registered_users (user_id));
+joinable!(coding_activities -> user_identities (user_id));
 joinable!(leaderboard_members -> leaderboards (leaderboard_id));
-joinable!(leaderboard_members -> registered_users (user_id));
+joinable!(leaderboard_members -> user_identities (user_id));
+joinable!(testausid_users -> user_identities (identity));
+joinable!(testaustime_users -> user_identities (identity));
 
 allow_tables_to_appear_in_same_query!(
     coding_activities,
     friend_relations,
     leaderboard_members,
     leaderboards,
-    registered_users,
+    testausid_users,
+    testaustime_users,
+    user_identities,
 );


### PR DESCRIPTION
This commit restructures the database for easy implementation of testausserveri-id authentication.

The only thing remaining to do after this is to add the actual logic and endpoints, the database already has the table.