### PR TITLE
feat(api): Give a more detailed response when user has no active session

### DIFF
--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -103,7 +103,7 @@ pub async fn get_current_activity(
             };
             Ok(web::Json(Some(current_heartbeat)))
         }
-        None => Ok(web::Json(None)),
+        None => Err(TimeError::NotActive),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,8 @@ pub enum TimeError {
     UnknownError,
     #[error("You are trying to register again after a short time")]
     TooManyRegisters,
+    #[error("The user has no active session")]
+    NotActive,
 }
 
 unsafe impl Send for TimeError {}
@@ -61,7 +63,9 @@ impl ResponseError for TimeError {
     fn status_code(&self) -> StatusCode {
         error!("{}", self);
         match self {
-            TimeError::UserNotFound | TimeError::LeaderboardNotFound => StatusCode::NOT_FOUND,
+            TimeError::UserNotFound | TimeError::LeaderboardNotFound | TimeError::NotActive => {
+                StatusCode::NOT_FOUND
+            }
             TimeError::BadUsername
             | TimeError::InvalidLength(_)
             | TimeError::BadId


### PR DESCRIPTION
/users/{user}/activity/current now returns a proper error

Closes #65 