### PR TITLE
feat: show current heartbeat in friend list and when adding a friend

### DIFF
--- a/docs/APISPEC.md
+++ b/docs/APISPEC.md
@@ -402,7 +402,7 @@ curl --location --request GET 'https://api.testaustime.fi/users/@me/activity/dat
 | duration | int | Duration of user code session in seconds |
 | project_name | string| Name of the project in which user have a code session |
 | language | string| Code language of the code session |
-| editor_name | string| Name of IDA (Visual Studio Code, IntelliJ, Neovim, etc.) in which user is coding |
+| editor_name | string| Name of IDE (Visual Studio Code, IntelliJ, Neovim, etc.) in which user is coding |
 | hostname | string| User hostname |
 </details>
 
@@ -592,7 +592,7 @@ Main endpoint of the service. Creates code session and logs current activity in 
 | --- | --- | --- |
 | language | string | Code language of the code session  |
 | hostname | string | User hostname |
-| editor_name | string | Name of IDA (Visual Studio Code, IntelliJ, Neovim, etc.) in which user is coding |
+| editor_name | string | Name of IDE (Visual Studio Code, IntelliJ, Neovim, etc.) in which user is coding |
 | project_name | string| Name of the project in which user have a code session |
 </details>
 
@@ -783,9 +783,28 @@ curl --request POST 'https://api.testaustime.fi/friends/add' \
 ```
 
 **Sample response**
-```HTTP
-200 OK
+
+```JSON
+{
+    "username": "Username",
+    "coding_time": {
+        "all_time": 0,
+        "past_month": 0,
+        "past_week": 0
+    },
+    "status": {
+        "started": "2023-03-02T12:13:53.121240868",
+        "duration": 5,
+        "heartbeat": {
+            "project_name": "My Project",
+            "language": "javascript",
+            "editor_name": "vscode",
+            "hostname": "mylaptop"
+        }
+    }
+}
 ```
+
 <details>
   <summary>Error examples:</summary>
 
@@ -824,6 +843,16 @@ curl --request GET ''https://api.testaustime.fi/friends/list' \
             "all_time": 0,
             "past_month": 0,
             "past_week": 0
+        },
+        "status": {
+            "started": "2023-03-02T12:13:53.121240868",
+            "duration": 5,
+            "heartbeat": {
+                "project_name": "My Project",
+                "language": "javascript",
+                "editor_name": "vscode",
+                "hostname": "mylaptop"
+            }
         }
     }
 ]
@@ -839,6 +868,14 @@ curl --request GET ''https://api.testaustime.fi/friends/list' \
 | all_time | int | Total duration of user code sessions in seconds |
 | past_month | int| Total duration of user code sessions in seconds for past month |
 | past_week | int| Total duration of user code sessions in seconds for past week |
+| status | Object | Information about the user's current activity |
+| started | string | Timestamp of when the session start |
+| duration | int | Duration of user code session in seconds |
+| heartbeat | Object | Information about the latest heartbeat |
+| project_name | string| Name of the project in which user have a code session |
+| language | string| Code language of the code session |
+| editor_name | string| Name of IDE (Visual Studio Code, IntelliJ, Neovim, etc.) in which user is coding |
+| hostname | string| User hostname |
 </details>
 
 #### <a name="regenerate_fc"></a>  [3. POST /friends/regenerate](#friends)

--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -9,7 +9,7 @@ use crate::{
     api::activity::HeartBeatMemoryStore,
     database::Database,
     error::TimeError,
-    models::{CodingTimeSteps, CurrentHeartBeat, FriendWithTimeAndStatus, UserId},
+    models::{CodingTimeSteps, CurrentActivity, FriendWithTimeAndStatus, UserId},
 };
 
 #[post("/friends/add")]
@@ -47,7 +47,7 @@ pub async fn add_friend(
                 status: heartbeats.get(&friend.id).map(|heartbeat| {
                     let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
                     drop(heartbeat);
-                    CurrentHeartBeat {
+                    CurrentActivity {
                         started: start_time,
                         duration: duration.num_seconds(),
                         heartbeat: inner_heartbeat,
@@ -85,7 +85,7 @@ pub async fn get_friends(
                     status: heartbeats.get(&friend_id).map(|heartbeat| {
                         let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
                         drop(heartbeat);
-                        CurrentHeartBeat {
+                        CurrentActivity {
                             started: start_time,
                             duration: duration.num_seconds(),
                             heartbeat: inner_heartbeat,

--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -6,9 +6,10 @@ use actix_web::{
 use diesel::result::DatabaseErrorKind;
 
 use crate::{
+    api::activity::HeartBeatMemoryStore,
     database::Database,
     error::TimeError,
-    models::{CodingTimeSteps, FriendWithTime, UserId},
+    models::{CodingTimeSteps, CurrentHeartBeat, FriendWithTimeAndStatus, UserId},
 };
 
 #[post("/friends/add")]
@@ -16,6 +17,7 @@ pub async fn add_friend(
     user: UserId,
     body: String,
     db: Data<Database>,
+    heartbeats: Data<HeartBeatMemoryStore>,
 ) -> Result<impl Responder, TimeError> {
     let mut conn = db.get()?;
     match block(move || conn.add_friend(user.id, body.trim().trim_start_matches("ttfc_"))).await? {
@@ -32,7 +34,7 @@ pub async fn add_friend(
         }
         Ok(friend) => {
             let mut conn = db.get()?;
-            let friend_with_time = FriendWithTime {
+            let friend_with_time = FriendWithTimeAndStatus {
                 username: friend.username.clone(),
                 coding_time: match block(move || conn.get_coding_time_steps(friend.id)).await {
                     Ok(coding_time_steps) => coding_time_steps,
@@ -42,6 +44,19 @@ pub async fn add_friend(
                         past_week: 0,
                     },
                 },
+                status: match heartbeats.get(&friend.id) {
+                    Some(heartbeat) => {
+                        let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
+                        drop(heartbeat);
+                        let current_heartbeat = CurrentHeartBeat {
+                            started: start_time,
+                            duration: duration.num_seconds(),
+                            heartbeat: inner_heartbeat,
+                        };
+                        Some(current_heartbeat)
+                    }
+                    None => None,
+                },
             };
 
             Ok(web::Json(friend_with_time))
@@ -50,14 +65,18 @@ pub async fn add_friend(
 }
 
 #[get("/friends/list")]
-pub async fn get_friends(user: UserId, db: Data<Database>) -> Result<impl Responder, TimeError> {
+pub async fn get_friends(
+    user: UserId,
+    db: Data<Database>,
+    heartbeats: Data<HeartBeatMemoryStore>,
+) -> Result<impl Responder, TimeError> {
     let mut conn = db.get()?;
     match block(move || conn.get_friends(user.id)).await? {
         Ok(friends) => {
             let friends_with_time = futures::future::join_all(friends.iter().map(|friend| async {
                 let mut conn2 = db.get().unwrap();
                 let friend_id = friend.id;
-                FriendWithTime {
+                FriendWithTimeAndStatus {
                     username: friend.username.clone(),
                     coding_time: match block(move || conn2.get_coding_time_steps(friend_id)).await {
                         Ok(coding_time_steps) => coding_time_steps,
@@ -66,6 +85,19 @@ pub async fn get_friends(user: UserId, db: Data<Database>) -> Result<impl Respon
                             past_month: 0,
                             past_week: 0,
                         },
+                    },
+                    status: match heartbeats.get(&friend_id) {
+                        Some(heartbeat) => {
+                            let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
+                            drop(heartbeat);
+                            let current_heartbeat = CurrentHeartBeat {
+                                started: start_time,
+                                duration: duration.num_seconds(),
+                                heartbeat: inner_heartbeat,
+                            };
+                            Some(current_heartbeat)
+                        }
+                        None => None,
                     },
                 }
             }))

--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -44,19 +44,15 @@ pub async fn add_friend(
                         past_week: 0,
                     },
                 },
-                status: match heartbeats.get(&friend.id) {
-                    Some(heartbeat) => {
-                        let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
-                        drop(heartbeat);
-                        let current_heartbeat = CurrentHeartBeat {
-                            started: start_time,
-                            duration: duration.num_seconds(),
-                            heartbeat: inner_heartbeat,
-                        };
-                        Some(current_heartbeat)
+                status: heartbeats.get(&friend.id).map(|heartbeat| {
+                    let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
+                    drop(heartbeat);
+                    CurrentHeartBeat {
+                        started: start_time,
+                        duration: duration.num_seconds(),
+                        heartbeat: inner_heartbeat,
                     }
-                    None => None,
-                },
+                }),
             };
 
             Ok(web::Json(friend_with_time))
@@ -86,19 +82,15 @@ pub async fn get_friends(
                             past_week: 0,
                         },
                     },
-                    status: match heartbeats.get(&friend_id) {
-                        Some(heartbeat) => {
-                            let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
-                            drop(heartbeat);
-                            let current_heartbeat = CurrentHeartBeat {
-                                started: start_time,
-                                duration: duration.num_seconds(),
-                                heartbeat: inner_heartbeat,
-                            };
-                            Some(current_heartbeat)
+                    status: heartbeats.get(&friend_id).map(|heartbeat| {
+                        let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
+                        drop(heartbeat);
+                        CurrentHeartBeat {
+                            started: start_time,
+                            duration: duration.num_seconds(),
+                            heartbeat: inner_heartbeat,
                         }
-                        None => None,
-                    },
+                    }),
                 }
             }))
             .await;

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -4,14 +4,14 @@ use actix_web::{
     HttpResponse, Responder,
 };
 use chrono::{Duration, Local};
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
 
 use crate::{
     api::activity::HeartBeatMemoryStore,
     database::Database,
     error::TimeError,
-    models::{UserId, UserIdentity},
-    requests::{DataRequest, HeartBeat},
+    models::{CurrentHeartBeat, UserId, UserIdentity},
+    requests::DataRequest,
     utils::group_by_language,
 };
 
@@ -57,13 +57,6 @@ pub async fn delete_user(
         block(move || conn.delete_user(user.id)).await??;
     }
     Ok(HttpResponse::Ok().finish())
-}
-
-#[derive(Serialize)]
-pub struct CurrentHeartBeat {
-    pub started: chrono::NaiveDateTime,
-    pub duration: i64,
-    pub heartbeat: HeartBeat,
 }
 
 #[get("/users/{username}/activity/current")]

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -10,7 +10,7 @@ use crate::{
     api::activity::HeartBeatMemoryStore,
     database::Database,
     error::TimeError,
-    models::{CurrentHeartBeat, UserId, UserIdentity},
+    models::{CurrentActivity, UserId, UserIdentity},
     requests::DataRequest,
     utils::group_by_language,
 };
@@ -89,7 +89,7 @@ pub async fn get_current_activity(
         Some(heartbeat) => {
             let (inner_heartbeat, start_time, duration) = heartbeat.to_owned();
             drop(heartbeat);
-            let current_heartbeat = CurrentHeartBeat {
+            let current_heartbeat = CurrentActivity {
                 started: start_time,
                 duration: duration.num_seconds(),
                 heartbeat: inner_heartbeat,

--- a/src/models.rs
+++ b/src/models.rs
@@ -215,7 +215,7 @@ pub struct CodingTimeSteps {
 }
 
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Debug, Clone)]
-pub struct CurrentHeartBeat {
+pub struct CurrentActivity {
     pub started: chrono::NaiveDateTime,
     pub duration: i64,
     pub heartbeat: HeartBeat,
@@ -225,5 +225,5 @@ pub struct CurrentHeartBeat {
 pub struct FriendWithTimeAndStatus {
     pub username: String,
     pub coding_time: CodingTimeSteps,
-    pub status: Option<CurrentHeartBeat>,
+    pub status: Option<CurrentActivity>,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -44,7 +44,7 @@ pub struct TestaustimeUser {
     pub identity: i32,
 }
 
-use crate::schema::testaustime_users;
+use crate::{requests::HeartBeat, schema::testaustime_users};
 
 #[derive(Insertable, Serialize, Clone)]
 #[diesel(table_name = testaustime_users)]
@@ -214,8 +214,16 @@ pub struct CodingTimeSteps {
     pub past_week: i32,
 }
 
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Debug, Clone)]
+pub struct CurrentHeartBeat {
+    pub started: chrono::NaiveDateTime,
+    pub duration: i64,
+    pub heartbeat: HeartBeat,
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
-pub struct FriendWithTime {
+pub struct FriendWithTimeAndStatus {
     pub username: String,
     pub coding_time: CodingTimeSteps,
+    pub status: Option<CurrentHeartBeat>,
 }


### PR DESCRIPTION
This PR adds a `status` field to the response of `GET /friends/list` and `POST /friends/add` showing the current heartbeat status of that friend. 

Getting the current heartbeat could be refactored into its own function, but I wasn't sure where to place that so I just copy-pasted it.

Example responses:
`POST /friends/add`:
```json
{
  "username": "testuser2",
  "coding_time": {
    "all_time": 0,
    "past_month": 0,
    "past_week": 0
  },
  "status": {
    "started": "2023-02-21T00:52:56.083467079",
    "duration": 5,
    "heartbeat": {
      "project_name": null,
      "language": null,
      "editor_name": null,
      "hostname": null
    }
  }
}
```


`GET /friends/list`:
```json
[
  {
    "username": "testuser2",
    "coding_time": {
      "all_time": 0,
      "past_month": 0,
      "past_week": 0
    },
    "status": {
      "started": "2023-02-21T01:03:04.610385534",
      "duration": 3,
      "heartbeat": {
        "project_name": null,
        "language": null,
        "editor_name": null,
        "hostname": null
      }
    }
  }
]
```