### PR TITLE
refactor: get rid of leaderboard cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,6 @@ async fn main() -> std::io::Result<()> {
     );
 
     let heartbeat_store = Data::new(api::activity::HeartBeatMemoryStore::new());
-    let leaderboard_cache = Data::new(api::leaderboards::LeaderboardCache::new());
 
     let secured_access_token_storage = Data::new(SecuredAccessTokenStorage::new());
 
@@ -182,7 +181,6 @@ async fn main() -> std::io::Result<()> {
                     scope
                 }
             })
-            .app_data(Data::clone(&leaderboard_cache))
             .app_data(Data::clone(&database))
             .app_data(Data::clone(&heartbeat_store));
         #[cfg(feature = "testausid")]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -32,7 +32,6 @@ fn init_test_services(cfg: &mut ServiceConfig) {
     );
 
     let heartbeat_store = Data::new(crate::api::activity::HeartBeatMemoryStore::new());
-    let leaderboard_cache = Data::new(crate::api::leaderboards::LeaderboardCache::new());
 
     let secured_access_token_storage = Data::new(crate::SecuredAccessTokenStorage::new());
 
@@ -115,8 +114,7 @@ fn init_test_services(cfg: &mut ServiceConfig) {
                 }
             }),
     )
-    .app_data(Data::clone(&heartbeat_store))
-    .app_data(Data::clone(&leaderboard_cache));
+    .app_data(Data::clone(&heartbeat_store));
     #[cfg(feature = "testausid")]
     {
         cfg.app_data(Data::new(client));


### PR DESCRIPTION
After #102 I personally deem the caching of leaderboards unnecessary, at least for now.
The leaderboard cache also causes some due to it not being invalidated when for example the invite code is regenerated.
This is by far the easiest solution to those issues.